### PR TITLE
Add CrazyS simulation platform to the external projects webpage

### DIFF
--- a/src/support/external-projects.md
+++ b/src/support/external-projects.md
@@ -30,6 +30,12 @@ Alternate firmware implementations and uses for the Crazyradio
 | NRF research firmware from Bastille Research  || <https://github.com/BastilleResearch/nrf-research-firmware> |
 | MouseJack device discovery and research tools || <https://github.com/BastilleResearch/nrf-research-firmware> |
 
+## Crazyflie simulator
+
+Project aimed to modeling, developing and integrating the Crazyflie 2.0 nano-quadcopter in the physics based simulation environment Gazebo. 
+ 
+| CrazyS | The University of Sannio in Benevento, Italy, has implemented a software-in-the-loop simulation platform for simulating Crazyflie behavior in the Gazebo 3D simulation environment. | <https://github.com/gsilano/CrazyS> |
+
 ## Swarming
 
 Projects aiming at supporting swarms. They might also be useful for controlling single Crazyflies.

--- a/src/support/external-projects.md
+++ b/src/support/external-projects.md
@@ -32,7 +32,7 @@ Alternate firmware implementations and uses for the Crazyradio
 
 ## Swarming
 
-Projects aiming at supporting swarms. They might also be useful for controling single Crazyflies.
+Projects aiming at supporting swarms. They might also be useful for controlling single Crazyflies.
 
 | Crazyswarm | The ACT lab at USC has implemented a library to handle large swarms of Crazyflies. | <https://github.com/USC-ACTLab/crazyswarm> |
 | ![ROS](/images/icons/ros_32.png) || <https://github.com/whoenig/crazyflie_ros> |


### PR DESCRIPTION
Added CrazyS simulation platform to the external projects webpage. Moreover, a typo in the text has been fixed.