### PR TITLE
Added directive to exclude repo docs from search indexes

### DIFF
--- a/src/_includes/head.html
+++ b/src/_includes/head.html
@@ -1,6 +1,9 @@
 <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    {% if page contains "no_search_index" and page.no_search_index %}
+    <meta name="robots" content="noindex, follow" />
+    {% endif %}
     <link rel="profile" href="http://gmpg.org/xfn/11">
     <link rel="alternate" type="application/rss+xml" title="Bitcraze » Feed" href="/feed/" data-proofer-ignore>
     <link rel="alternate" type="application/rss+xml" title="Bitcraze » Comments Feed" href="/comments/feed/" data-proofer-ignore>

--- a/tools/build/download_docs
+++ b/tools/build/download_docs
@@ -10,6 +10,7 @@ downloadFile="${tmp}/download.zip"
 function downloadGithubRepoDoc() {
   local name=$1
   local tag=$2
+  local directives=$3
   local nameTag=${name}/${tag}
   local repoRootDir=${dstDir}/${name}
   local repoDir=${dstDir}/${nameTag}
@@ -40,7 +41,7 @@ function downloadGithubRepoDoc() {
 
       # Massage data to move it into a namespace and genereate menus
       echo "Updating docs source files"
-      ${scriptDir}/../docs/format_docs ${repoDir} ${ns} ${name} ${tag} ${repoDir}/_data/menu.yml ${dataDir}/docs_menu.yml ${dataDir}/docs_tag_list.yml
+      ${scriptDir}/../docs/format_docs ${repoDir} ${ns} ${name} ${tag} ${repoDir}/_data/menu.yml ${dataDir}/docs_menu.yml ${dataDir}/docs_tag_list.yml ${directives}
   fi
 }
 
@@ -51,47 +52,47 @@ echo "Downloading repository documentation..."
 # Note: The order of downloads determines the order of versions in UI menus
 
 downloadGithubRepoDoc "crazyflie-firmware" "master"
-downloadGithubRepoDoc "crazyflie-firmware" "2022.01"
-downloadGithubRepoDoc "crazyflie-firmware" "2021.06"
-downloadGithubRepoDoc "crazyflie-firmware" "2021.03"
-downloadGithubRepoDoc "crazyflie-firmware" "2021.01"
-downloadGithubRepoDoc "crazyflie-firmware" "2020.09"
-downloadGithubRepoDoc "crazyflie-firmware" "2020.06"
-downloadGithubRepoDoc "crazyflie-firmware" "2020.04"
-downloadGithubRepoDoc "crazyflie-firmware" "2020.02"
-downloadGithubRepoDoc "crazyflie-firmware" "2019.09"
+downloadGithubRepoDoc "crazyflie-firmware" "2022.01" "no_search_index"
+downloadGithubRepoDoc "crazyflie-firmware" "2021.06" "no_search_index"
+downloadGithubRepoDoc "crazyflie-firmware" "2021.03" "no_search_index"
+downloadGithubRepoDoc "crazyflie-firmware" "2021.01" "no_search_index"
+downloadGithubRepoDoc "crazyflie-firmware" "2020.09" "no_search_index"
+downloadGithubRepoDoc "crazyflie-firmware" "2020.06" "no_search_index"
+downloadGithubRepoDoc "crazyflie-firmware" "2020.04" "no_search_index"
+downloadGithubRepoDoc "crazyflie-firmware" "2020.02" "no_search_index"
+downloadGithubRepoDoc "crazyflie-firmware" "2019.09" "no_search_index"
 
 downloadGithubRepoDoc "crazyflie2-nrf-firmware" "master"
-downloadGithubRepoDoc "crazyflie2-nrf-firmware" "2022.01"
-downloadGithubRepoDoc "crazyflie2-nrf-firmware" "2021.06"
-downloadGithubRepoDoc "crazyflie2-nrf-firmware" "2021.03"
-downloadGithubRepoDoc "crazyflie2-nrf-firmware" "2020.09"
-downloadGithubRepoDoc "crazyflie2-nrf-firmware" "2020.06"
-downloadGithubRepoDoc "crazyflie2-nrf-firmware" "2020.04"
-downloadGithubRepoDoc "crazyflie2-nrf-firmware" "2020.02"
-downloadGithubRepoDoc "crazyflie2-nrf-firmware" "2019.09"
+downloadGithubRepoDoc "crazyflie2-nrf-firmware" "2022.01" "no_search_index"
+downloadGithubRepoDoc "crazyflie2-nrf-firmware" "2021.06" "no_search_index"
+downloadGithubRepoDoc "crazyflie2-nrf-firmware" "2021.03" "no_search_index"
+downloadGithubRepoDoc "crazyflie2-nrf-firmware" "2020.09" "no_search_index"
+downloadGithubRepoDoc "crazyflie2-nrf-firmware" "2020.06" "no_search_index"
+downloadGithubRepoDoc "crazyflie2-nrf-firmware" "2020.04" "no_search_index"
+downloadGithubRepoDoc "crazyflie2-nrf-firmware" "2020.02" "no_search_index"
+downloadGithubRepoDoc "crazyflie2-nrf-firmware" "2019.09" "no_search_index"
 
 downloadGithubRepoDoc "crazyflie-lib-python" "master"
-downloadGithubRepoDoc "crazyflie-lib-python" "0.1.17.1"
-downloadGithubRepoDoc "crazyflie-lib-python" "0.1.16"
-downloadGithubRepoDoc "crazyflie-lib-python" "0.1.14.1"
-downloadGithubRepoDoc "crazyflie-lib-python" "0.1.13.1"
-downloadGithubRepoDoc "crazyflie-lib-python" "0.1.12"
-downloadGithubRepoDoc "crazyflie-lib-python" "0.1.11"
-downloadGithubRepoDoc "crazyflie-lib-python" "0.1.10"
-downloadGithubRepoDoc "crazyflie-lib-python" "0.1.9"
+downloadGithubRepoDoc "crazyflie-lib-python" "0.1.17.1" "no_search_index"
+downloadGithubRepoDoc "crazyflie-lib-python" "0.1.16" "no_search_index"
+downloadGithubRepoDoc "crazyflie-lib-python" "0.1.14.1" "no_search_index"
+downloadGithubRepoDoc "crazyflie-lib-python" "0.1.13.1" "no_search_index"
+downloadGithubRepoDoc "crazyflie-lib-python" "0.1.12" "no_search_index"
+downloadGithubRepoDoc "crazyflie-lib-python" "0.1.11" "no_search_index"
+downloadGithubRepoDoc "crazyflie-lib-python" "0.1.10" "no_search_index"
+downloadGithubRepoDoc "crazyflie-lib-python" "0.1.9" "no_search_index"
 
 downloadGithubRepoDoc "crazyflie-clients-python" "master"
-downloadGithubRepoDoc "crazyflie-clients-python" "2022.1"
-downloadGithubRepoDoc "crazyflie-clients-python" "2021.6"
-downloadGithubRepoDoc "crazyflie-clients-python" "2021.3"
-downloadGithubRepoDoc "crazyflie-clients-python" "2021.1"
-downloadGithubRepoDoc "crazyflie-clients-python" "2020.09"
-downloadGithubRepoDoc "crazyflie-clients-python" "2019.09"
+downloadGithubRepoDoc "crazyflie-clients-python" "2022.1" "no_search_index"
+downloadGithubRepoDoc "crazyflie-clients-python" "2021.6" "no_search_index"
+downloadGithubRepoDoc "crazyflie-clients-python" "2021.3" "no_search_index"
+downloadGithubRepoDoc "crazyflie-clients-python" "2021.1" "no_search_index"
+downloadGithubRepoDoc "crazyflie-clients-python" "2020.09" "no_search_index"
+downloadGithubRepoDoc "crazyflie-clients-python" "2019.09" "no_search_index"
 
 downloadGithubRepoDoc "lps-node-firmware" "master"
-downloadGithubRepoDoc "lps-node-firmware" "2020.09"
-downloadGithubRepoDoc "lps-node-firmware" "2019.09"
+downloadGithubRepoDoc "lps-node-firmware" "2020.09" "no_search_index"
+downloadGithubRepoDoc "lps-node-firmware" "2019.09" "no_search_index"
 
 downloadGithubRepoDoc "crazyradio-firmware" "master"
 

--- a/tools/docs/format_docs
+++ b/tools/docs/format_docs
@@ -11,9 +11,10 @@ repo_tag = ARGV[3]
 docs_menu_file = ARGV[4]
 shared_docs_menus_file = ARGV[5]
 docs_tag_list_file = ARGV[6]
+directives = ARGV[7]
 
 formatter = DocumentationFormatter.new()
 
-formatter.update_docs_content(docs_dir, ns, repo_name, repo_tag)
+formatter.update_docs_content(docs_dir, ns, repo_name, repo_tag, directives)
 formatter.add_to_docs_menus(docs_menu_file, shared_docs_menus_file, ns)
 formatter.add_to_docs_tag_list_file(docs_tag_list_file, repo_name, repo_tag)

--- a/tools/docs/test/documentation_formatter_test.rb
+++ b/tools/docs/test/documentation_formatter_test.rb
@@ -21,7 +21,7 @@ class TestDocumentationFormatter < Minitest::Test
     expected = @ns + '-' + @page_id
 
     # Test
-    actual_doc = @cut.update_doc(doc, @ns, @repo_name, @tag, true)
+    actual_doc = @cut.update_doc(doc, @ns, @repo_name, @tag, true, false)
 
     # Assert
     actual = YAML.load(actual_doc)
@@ -37,7 +37,7 @@ class TestDocumentationFormatter < Minitest::Test
     expected = ['/documentation/repository/' + @repo_name + '/' + @tag + '/a/page/', '/documentation/repository/' + @repo_name + '/' + @tag + '/other/page/']
 
     # Test
-    actual_doc = @cut.update_doc(doc, @ns, @repo_name, @tag, true)
+    actual_doc = @cut.update_doc(doc, @ns, @repo_name, @tag, true, false)
 
     # Assert
     actual = YAML.load(actual_doc)
@@ -53,7 +53,7 @@ class TestDocumentationFormatter < Minitest::Test
     expected = ['/documentation/repository/' + @repo_name + '/' + @tag + '/a/page/']
 
     # Test
-    actual_doc = @cut.update_doc(doc, @ns, @repo_name, @tag, true)
+    actual_doc = @cut.update_doc(doc, @ns, @repo_name, @tag, true, false)
 
     # Assert
     actual = YAML.load(actual_doc)
@@ -66,7 +66,7 @@ class TestDocumentationFormatter < Minitest::Test
     doc = generate_doc(@fm_default, '')
 
     # Test
-    actual_doc = @cut.update_doc(doc, @ns, @repo_name, @tag, true)
+    actual_doc = @cut.update_doc(doc, @ns, @repo_name, @tag, true, false)
 
     # Assert
     actual = YAML.load(actual_doc)
@@ -77,13 +77,26 @@ class TestDocumentationFormatter < Minitest::Test
     assert_equal(@ns, actual['ns'])
   end
 
+  def test_that_no_search_index_is_added_to_front_matter
+    # Fixture
+    doc = generate_doc(@fm_default, '')
+
+    # Test
+    actual_doc = @cut.update_doc(doc, @ns, @repo_name, @tag, true, true)
+
+    # Assert
+    actual = YAML.load(actual_doc)
+
+    assert_equal(true, actual['no_search_index'])
+  end
+
   def test_that_internal_absolute_old_urls_are_extended
     # Fixture
     doc = generate_doc(@fm_default, '[bla bla](/internal/link)')
     expected = '[bla bla](/documentation/repository/' + @repo_name + '/' + @tag + '/internal/link)'
 
     # Test
-    actual = @cut.update_doc(doc, @ns, @repo_name, @tag, true)
+    actual = @cut.update_doc(doc, @ns, @repo_name, @tag, true, false)
 
     # Assert
     assert(actual.include? expected)
@@ -95,7 +108,7 @@ class TestDocumentationFormatter < Minitest::Test
     expected = '[bla bla](/documentation/repository/' + @repo_name + '/' + @tag + '/internal/link)'
 
     # Test
-    actual = @cut.update_doc(doc, @ns, @repo_name, @tag, true)
+    actual = @cut.update_doc(doc, @ns, @repo_name, @tag, true, false)
 
     # Assert
     assert(actual.include? expected)
@@ -107,7 +120,7 @@ class TestDocumentationFormatter < Minitest::Test
     expected = '[bla bla](/documentation/repository/' + @repo_name + '/' + @tag + '/internal/link.md)'
 
     # Test
-    actual = @cut.update_doc(doc, @ns, @repo_name, @tag, true)
+    actual = @cut.update_doc(doc, @ns, @repo_name, @tag, true, false)
 
     # Assert
     assert(actual.include? expected)
@@ -119,7 +132,7 @@ class TestDocumentationFormatter < Minitest::Test
     expected = '[bla bla](relative/link)'
 
     # Test
-    actual = @cut.update_doc(doc, @ns, @repo_name, @tag, true)
+    actual = @cut.update_doc(doc, @ns, @repo_name, @tag, true, false)
 
     # Assert
     assert(actual.include? expected)
@@ -131,7 +144,7 @@ class TestDocumentationFormatter < Minitest::Test
     expected = '[bla bla](relative.md)'
 
     # Test
-    actual = @cut.update_doc(doc, @ns, @repo_name, @tag, true)
+    actual = @cut.update_doc(doc, @ns, @repo_name, @tag, true, false)
 
     # Assert
     assert(actual.include? expected)
@@ -143,7 +156,7 @@ class TestDocumentationFormatter < Minitest::Test
     expected = '[bla bla](/some/page/)'
 
     # Test
-    actual = @cut.update_doc(doc, @ns, @repo_name, @tag, true)
+    actual = @cut.update_doc(doc, @ns, @repo_name, @tag, true, false)
 
     # Assert
     assert(actual.include? expected)
@@ -155,7 +168,7 @@ class TestDocumentationFormatter < Minitest::Test
     expected = '[bla bla](/some/page/)'
 
     # Test
-    actual = @cut.update_doc(doc, @ns, @repo_name, @tag, false)
+    actual = @cut.update_doc(doc, @ns, @repo_name, @tag, false, false)
 
     # Assert
     assert(actual.include? expected)
@@ -168,7 +181,7 @@ class TestDocumentationFormatter < Minitest::Test
     expected = url
 
     # Test
-    actual = @cut.update_doc(doc, @ns, @repo_name, @tag, true)
+    actual = @cut.update_doc(doc, @ns, @repo_name, @tag, true, false)
 
     # Assert
     assert(actual.include? expected)
@@ -181,7 +194,7 @@ class TestDocumentationFormatter < Minitest::Test
     expected = url
 
     # Test
-    actual = @cut.update_doc(doc, @ns, @repo_name, @tag, true)
+    actual = @cut.update_doc(doc, @ns, @repo_name, @tag, true, false)
 
     # Assert
     assert(actual.include? expected)
@@ -193,7 +206,7 @@ class TestDocumentationFormatter < Minitest::Test
     expected = '[bla bla](https://github.com/bitcraze/the-repo/blob/the-tag/src/modules/interface/stabilizer_types.h)'
 
     # Test
-    actual = @cut.update_doc(doc, @ns, @repo_name, @tag, true)
+    actual = @cut.update_doc(doc, @ns, @repo_name, @tag, true, false)
 
     # Assert
     assert(actual.include? expected)
@@ -205,7 +218,7 @@ class TestDocumentationFormatter < Minitest::Test
     expected = '[bla bla](https://github.com/bitcraze/other-repo/blob/master/src/modules/interface/stabilizer_types.h)'
 
     # Test
-    actual = @cut.update_doc(doc, @ns, @repo_name, @tag, true)
+    actual = @cut.update_doc(doc, @ns, @repo_name, @tag, true, false)
 
     # Assert
     assert(actual.include? expected)
@@ -217,7 +230,7 @@ class TestDocumentationFormatter < Minitest::Test
     expected = '[bla bla](https://github.com/bitcraze/the-repo/blob/other-tag/src/modules/interface/stabilizer_types.h)'
 
     # Test
-    actual = @cut.update_doc(doc, @ns, @repo_name, @tag, true)
+    actual = @cut.update_doc(doc, @ns, @repo_name, @tag, true, false)
 
     # Assert
     assert(actual.include? expected)


### PR DESCRIPTION
Adding functionality that adds a `<meta name="robots" content="index, follow" />` tag to generated html, if the `no_search_index=true` in the front matter of a markdown page.

Also added the possibility to add "no_search_index" when downloading repo docs, which will add the meta tag to the full doc tree.

This will prevent search engines from indexing the marked pages.
