### PR TITLE
Rework anchor links

### DIFF
--- a/src/_plugins/media.rb
+++ b/src/_plugins/media.rb
@@ -258,7 +258,8 @@ module Jekyll
       def render(context)
         header = ''
         if @params.length >= 3
-          header = '<div><h3>%3$s</h3></div>' % @params
+          full_id = generate_id(@params[2])
+          header = '<div><h3 id="%1$s">%2$s</h3></div>' % [full_id, @params[2]]
         end
 
         html = '<div class="col-md-6">%1$s<div class="embed-responsive embed-responsive-%3$s"><div class="embed-responsive-item video-item-delayed-load" data-video-id="%2$s" style="background:url(https://i1.ytimg.com/vi/%2$s/0.jpg);" onclick="kraken.loadYoutubeVideo(this)"><i class="fa fa-play-circle fa-3x"></i></div></div></div>' % ([header] + @params)

--- a/src/_plugins/product.rb
+++ b/src/_plugins/product.rb
@@ -97,7 +97,8 @@ module Jekyll
       end
 
       def render(context)
-          '<h2><i class="fa %1$s bc-fa-fw"></i>%2$s</h2><div class="pp-catch-phrase">%3$s</div>' % @params
+        full_id = generate_id(@params[1])
+        '<h2 id="%4$s"><i class="fa %1$s bc-fa-fw"></i>%2$s</h2><div class="pp-catch-phrase">%3$s</div>' % [@params[0], @params[1], @params[2], full_id]
       end
     end
   end

--- a/src/_plugins/row_columns.rb
+++ b/src/_plugins/row_columns.rb
@@ -153,6 +153,8 @@ module Jekyll
       def render(context)
         title = @params[0]
         image = @params[1]
+        full_id = generate_id(title)
+
 
         context.stack do
           context['row_image_text_links'] = self
@@ -160,7 +162,7 @@ module Jekyll
 
           image_tag = image ? '<img src="' + image + '" alt="' + title + '">' : ''
 
-          '<section class="row content-area"><div class="col-md-12"><h3>' + title + '</h3></div>' +
+          '<section class="row content-area"><div class="col-md-12"><h3 id="' + full_id + '">' + title + '</h3></div>' +
           '</section><section class="row content-area">' +
           '<div class="col-md-3 doc-section-image">' + image_tag + '</div>' +
           '<div class="col-md-6">' + @text_content + '</div>' +
@@ -215,6 +217,7 @@ module Jekyll
       def render(context)
         title = @params[0]
         icon = @params[1]
+        full_id = generate_id(title)
 
         context.stack do
           context['row_image_text_links'] = self
@@ -223,7 +226,7 @@ module Jekyll
 
           icon_tag =  icon ? '<i class="fa '+ icon + ' fa-5x"></i>' : ''
 
-          '<section class="row content-area"><div class="col-md-12"><h3>' + title + '</h3></div>' +
+          '<section class="row content-area"><div class="col-md-12"><h3 id="' + full_id + '">' + title + '</h3></div>' +
           '</section><section class="row content-area">' +
           '<div class="col-md-2">' + icon_tag + '</div>' +
           '<div class="col-md-7">'  + @text_content  + '</div>' +
@@ -278,6 +281,7 @@ module Jekyll
       def render(context)
         title = @params[0]
         video  = @params[1]
+        full_id = generate_id(title)
 
         context.stack do
           context['row_image_text_links'] = self
@@ -285,7 +289,7 @@ module Jekyll
 
           video_tag = video ? '<video autobuffer controls autoplay muted loop><source src="' + video + '" type="video/mp4"></video>' : ''
 
-          '<section class="row content-area"><div class="col-md-12"><h3>' + title + '</h3></div>' +
+          '<section class="row content-area"><div class="col-md-12"><h3 id="' + full_id + '">' + title + '</h3></div>' +
           '</section><section class="row content-area">' +
           '<div class="col-md-3 doc-section-image video-no-controls">' + video_tag + '</div>' +
           '<div class="col-md-6">' + @text_content + '</div>' +

--- a/src/_plugins/step_instruction_tags.rb
+++ b/src/_plugins/step_instruction_tags.rb
@@ -42,7 +42,7 @@ module Jekyll
         raise 'Id "' + full_id + '" is already used!' if plugin_data.has_key?(full_id)
         plugin_data[full_id] = true
 
-        '<div class="step-instruction-intro"><h2 id="%1$s">%2$s<a class ="anchor-link" href="#%1$s"><i class="fa fa-link"></i></a></h2>%3$s</div>' % [full_id, @params[0], markup]
+        '<div class="step-instruction-intro"><h2 id="%1$s">%2$s</h2>%3$s</div>' % [full_id, @params[0], markup]
       end
 
       # Allow for empty body. Liquid will not output the rendered result otherwise
@@ -88,7 +88,7 @@ module Jekyll
         raise 'Id "' + full_id + '" is already used!' if plugin_data.has_key?(full_id)
         plugin_data[full_id] = true
 
-        '<div class="step-instruction-info-step"><h3 id="%1$s">%2$s<a class ="anchor-link" href="#%1$s"><i class="fa fa-link"></i></a></h3>%3$s</div>' % [full_id, @params[0], markup]
+        '<div class="step-instruction-info-step"><h3 id="%1$s">%2$s</h3>%3$s</div>' % [full_id, @params[0], markup]
       end
     end
 

--- a/src/_scss/_pages.scss
+++ b/src/_scss/_pages.scss
@@ -215,8 +215,7 @@ table {
     display: block;
 }
 
-
-// Step instruction
+// Anchor links
 .anchor-link {
     font-size: 0.7rem;
     padding-left: 1rem;
@@ -224,6 +223,18 @@ table {
     visibility: hidden;
     color: $bcLightGrey;
 }
+h3:hover {
+    .anchor-link {
+        visibility: visible;
+    }
+}
+h2:hover {
+    .anchor-link {
+        visibility: visible;
+    }
+}
+
+// Step instruction
 .step-instruction-intro {
     p {
         font-weight: 400;
@@ -234,11 +245,6 @@ table {
         font-weight: 500;
     }
 
-    h2:hover {
-      .anchor-link {
-        visibility: visible;
-      }
-    }
 }
 .step-instruction-info-step {
     margin-bottom: 50px;
@@ -251,12 +257,6 @@ table {
         font-size: 150%;
         border-width: 0 0 1px 0;
         border-style: solid;
-    }
-
-    h3:hover {
-      .anchor-link {
-        visibility: visible;
-      }
     }
 }
 

--- a/src/js/kraken.js
+++ b/src/js/kraken.js
@@ -68,6 +68,31 @@ var kraken = {
     }
   },
 
+  addLinksToTags: function(tag_type) {
+    let elements = document.getElementsByTagName(tag_type);
+    for (let element of elements) {
+      if (element.hasAttribute("id")) {
+        let id = element.id;
+
+        let iElem = document.createElement('i');
+        iElem.classList.add('fa');
+        iElem.classList.add('fa-link');
+
+        let aElem = document.createElement('a');
+        aElem.classList.add('anchor-link');
+        aElem.href = '#' + id;
+
+        element.appendChild(aElem).appendChild(iElem);
+      }
+    }
+  },
+
+  addLinksToHeaders: function() {
+    kraken.addLinksToTags('h1');
+    kraken.addLinksToTags('h2');
+    kraken.addLinksToTags('h3');
+  },
+
   poplinkShowPopup: function(id, popupKey) {
     var container = document.getElementById("poplinkcontainer");
     if (container == null) {
@@ -131,3 +156,4 @@ var kraken = {
 
 window.addEventListener('click', kraken.poplinkCloseClickListener);
 window.addEventListener('keydown', kraken.poplinkCloseKeyListener);
+document.addEventListener("DOMContentLoaded", kraken.addLinksToHeaders);

--- a/test/_plugins/media_test.rb
+++ b/test/_plugins/media_test.rb
@@ -153,7 +153,7 @@ class TestMedia < Testbase
                   <div class="row">
                     <div class="col-md-6">
                       <div>
-                        <h3>Some header</h3>
+                        <h3 id="some-header">Some header</h3>
                       </div>
                       <div class="embed-responsive embed-responsive-16by9">
                         <div class="embed-responsive-item video-item-delayed-load" data-video-id="id" style="background:url(https://i1.ytimg.com/vi/id/0.jpg);" onclick="kraken.loadYoutubeVideo(this)">
@@ -179,7 +179,7 @@ class TestMedia < Testbase
                   <div class="row">
                     <div class="col-md-6">
                       <div>
-                        <h3>Some header</h3>
+                        <h3 id="some-header">Some header</h3>
                       </div>
                       <div class="embed-responsive embed-responsive-16by9">
                         <div class="embed-responsive-item video-item-delayed-load" data-video-id="id1" style="background:url(https://i1.ytimg.com/vi/id1/0.jpg);" onclick="kraken.loadYoutubeVideo(this)">
@@ -189,7 +189,7 @@ class TestMedia < Testbase
                     </div>
                     <div class="col-md-6">
                       <div>
-                        <h3>Other header</h3>
+                        <h3 id="other-header">Other header</h3>
                       </div>
                       <div class="embed-responsive embed-responsive-16by9">
                         <div class="embed-responsive-item video-item-delayed-load" data-video-id="id2" style="background:url(https://i1.ytimg.com/vi/id2/0.jpg);" onclick="kraken.loadYoutubeVideo(this)">
@@ -201,7 +201,7 @@ class TestMedia < Testbase
                   <div class="row">
                     <div class="col-md-6">
                       <div>
-                        <h3>Some header</h3>
+                        <h3 id="some-header">Some header</h3>
                       </div>
                       <div class="embed-responsive embed-responsive-16by9">
                         <div class="embed-responsive-item video-item-delayed-load" data-video-id="id3" style="background:url(https://i1.ytimg.com/vi/id3/0.jpg);" onclick="kraken.loadYoutubeVideo(this)">
@@ -211,7 +211,7 @@ class TestMedia < Testbase
                     </div>
                     <div class="col-md-6">
                       <div>
-                        <h3>Some header</h3>
+                        <h3 id="some-header">Some header</h3>
                       </div>
                       <div class="embed-responsive embed-responsive-16by9">
                         <div class="embed-responsive-item video-item-delayed-load" data-video-id="id4" style="background:url(https://i1.ytimg.com/vi/id4/0.jpg);" onclick="kraken.loadYoutubeVideo(this)">

--- a/test/_plugins/product_test.rb
+++ b/test/_plugins/product_test.rb
@@ -78,7 +78,7 @@ class TestProduct < Testbase
     %}'
 
     expected = '
-    <h2><i class="fa fa-icon bc-fa-fw"></i>Some title text</h2>
+    <h2 id="some-title-text"><i class="fa fa-icon bc-fa-fw"></i>Some title text</h2>
     <div class="pp-catch-phrase">Some descriptive text</div>
     '
 

--- a/test/_plugins/row_columns_test.rb
+++ b/test/_plugins/row_columns_test.rb
@@ -69,7 +69,7 @@ class TestRowCols < Testbase
     tag = '{% row_image_text_links The title;the/image.jpg%}md1{% row_text %}md1{% endrow_text %}{% row_links %}md2{% endrow_links %}{% endrow_image_text_links %}'
     expected = '
     <section class="row content-area">
-        <div class="col-md-12"><h3>The title</h3></div>
+        <div class="col-md-12"><h3 id="the-title">The title</h3></div>
     </section>
     <section class="row content-area">
         <div class="col-md-3 doc-section-image"><img src="the/image.jpg" alt="The title"></div>
@@ -90,7 +90,7 @@ class TestRowCols < Testbase
     tag = '{% row_image_text_links The title%}md1{% row_text %}md1{% endrow_text %}{% row_links %}md2{% endrow_links %}{% endrow_image_text_links %}'
     expected = '
     <section class="row content-area">
-        <div class="col-md-12"><h3>The title</h3></div>
+        <div class="col-md-12"><h3 id="the-title">The title</h3></div>
     </section>
     <section class="row content-area">
         <div class="col-md-3 doc-section-image"></div>
@@ -111,7 +111,7 @@ class TestRowCols < Testbase
     tag = '{% row_image_text_links The title%}md1{% row_text %}md1{% endrow_text %}{% endrow_image_text_links %}'
     expected = '
     <section class="row content-area">
-        <div class="col-md-12"><h3>The title</h3></div>
+        <div class="col-md-12"><h3 id="the-title">The title</h3></div>
     </section>
     <section class="row content-area">
         <div class="col-md-3 doc-section-image"></div>
@@ -132,7 +132,7 @@ class TestRowCols < Testbase
     tag = '{% row_video_text_links The title;the/video.mp4%}md1{% row_text %}md1{% endrow_text %}{% row_links %}md2{% endrow_links %}{% endrow_video_text_links %}'
     expected = '
     <section class="row content-area">
-        <div class="col-md-12"><h3>The title</h3></div>
+        <div class="col-md-12"><h3 id="the-title">The title</h3></div>
     </section>
     <section class="row content-area">
         <div class="col-md-3 doc-section-image video-no-controls">
@@ -158,7 +158,7 @@ class TestRowCols < Testbase
     tag = '{% row_icon_text_links The title;fa-icon%}md1{% row_text %}md1{% endrow_text %}{% row_links %}md2{% endrow_links %}{% endrow_icon_text_links %}'
     expected = '
     <section class="row content-area">
-        <div class="col-md-12"><h3>The title</h3></div>
+        <div class="col-md-12"><h3 id="the-title">The title</h3></div>
     </section>
     <section class="row content-area">
         <div class="col-md-2">

--- a/test/_plugins/step_instruction_tags_test.rb
+++ b/test/_plugins/step_instruction_tags_test.rb
@@ -18,7 +18,7 @@ class TestStepInstructionTags < Testbase
 
     tag = '{% si_intro My title %}md{% endsi_intro %}'
 
-    expected = '<div class="step-instruction-intro"><h2 id="my-title">My title<a class ="anchor-link" href="#my-title"><i class="fa fa-link"></i></a></h2>converted md</div>'
+    expected = '<div class="step-instruction-intro"><h2 id="my-title">My title</h2>converted md</div>'
 
     # Test
     actual = Liquid::Template.parse(tag).render!({'page' => {}}, registers: {site: @site_mock})
@@ -34,7 +34,7 @@ class TestStepInstructionTags < Testbase
 
     tag = '{% si_intro My title %}{% endsi_intro %}'
 
-    expected = '<div class="step-instruction-intro"><h2 id="my-title">My title<a class ="anchor-link" href="#my-title"><i class="fa fa-link"></i></a></h2>converted md</div>'
+    expected = '<div class="step-instruction-intro"><h2 id="my-title">My title</h2>converted md</div>'
 
     # Test
     actual = Liquid::Template.parse(tag).render!({'page' => {}}, registers: {site: @site_mock})
@@ -50,7 +50,7 @@ class TestStepInstructionTags < Testbase
 
     tag = '{% si_intro My title; my-id %}md{% endsi_intro %}'
 
-    expected = '<div class="step-instruction-intro"><h2 id="my-id">My title<a class ="anchor-link" href="#my-id"><i class="fa fa-link"></i></a></h2>converted md</div>'
+    expected = '<div class="step-instruction-intro"><h2 id="my-id">My title</h2>converted md</div>'
 
     # Test
     actual = Liquid::Template.parse(tag).render!({'page' => {}}, registers: {site: @site_mock})
@@ -66,7 +66,7 @@ class TestStepInstructionTags < Testbase
 
     tag = '{% si_step My title %}md{% endsi_step %}'
 
-    expected = '<div class="step-instruction-info-step"><h3 id="my-title">My title<a class ="anchor-link" href="#my-title"><i class="fa fa-link"></i></a></h3>converted md</div>'
+    expected = '<div class="step-instruction-info-step"><h3 id="my-title">My title</h3>converted md</div>'
 
     # Test
     actual = Liquid::Template.parse(tag).render!({'page' => {}}, registers: {site: @site_mock})
@@ -82,7 +82,7 @@ class TestStepInstructionTags < Testbase
 
     tag = '{% si_step My title; my-id %}md{% endsi_step %}'
 
-    expected = '<div class="step-instruction-info-step"><h3 id="my-id">My title<a class ="anchor-link" href="#my-id"><i class="fa fa-link"></i></a></h3>converted md</div>'
+    expected = '<div class="step-instruction-info-step"><h3 id="my-id">My title</h3>converted md</div>'
 
     # Test
     actual = Liquid::Template.parse(tag).render({'page' => {}}, registers: {site: @site_mock})


### PR DESCRIPTION
This PR adds anchor links to all headers

* Relevant liquid plugins adds an id to the <h> tag
* Kramdown automatically generates ids on <h> tags
* A simple js adds an <a> tag to all <h> tags with an id on page load
* css updated