### PR TITLE
Add check that there are no <H1>s in repo docs

### DIFF
--- a/tools/build/validate
+++ b/tools/build/validate
@@ -7,6 +7,7 @@ STDOUT.sync = true
 require 'html-proofer'
 # Add checks for our urls
 require_relative '../validate/src/url_check'
+require_relative '../validate/src/repo_docs_check'
 
 
 root_path = "./_site"
@@ -15,13 +16,13 @@ repo_docs_path = "./_site/documentation/repository"
 # Ignore internal links to our blog, they can not be tested in this context, hese links are on the format "/category/crazyflie/" or "/2020/05/some-title"
 def check_internal_links(root, options)
   options[:disable_external] = true
-  HTMLProofer.check_directory(root, options = options).run
+  HTMLProofer.check_directory(root, options).run
 end
 
 def check_external_links(root, options)
   begin
     options[:disable_external] = false
-    HTMLProofer.check_directory(root, options = options).run
+    HTMLProofer.check_directory(root, options).run
   rescue Exception => e
     puts "\e[31mWARNING: All external references could not be validated. The reference(s) might be faulty or the external site is maybe down?\e[0m\n"
   end
@@ -45,14 +46,14 @@ end
 puts "Ignored paths"
 puts ignored_files
 
-# Ignore internal links to our blog, they can not be tested in this context, hese links are on the format "/category/crazyflie/" or "/2020/05/some-title"
+# Ignore internal links to our blog, they can not be tested in this context, these links are on the format "/category/crazyflie/" or "/2020/05/some-title"
 options = {
   allow_hash_href: true,
   disable_external: true,
   enforce_https: false,
   ignore_urls: [/\/category\/.*/, /\/\d+\/\d+\/.*/],
   ignore_files: ignored_files,
-  checks: ['UrlCheck', 'Images', 'Scripts', 'Links']
+  checks: ['UrlCheck', 'RepoDocsCheck', 'Images', 'Scripts', 'Links']
 }
 
 puts 'Checking html and internal links...'

--- a/tools/validate/src/repo_docs_check.rb
+++ b/tools/validate/src/repo_docs_check.rb
@@ -1,0 +1,8 @@
+class RepoDocsCheck < ::HTMLProofer::Check
+  def run
+    @html.css('.repo-docs-content h1').each do |node|
+      h1 = create_element(node)
+      return add_failure("H1 tags not allowed in repo docs", line: h1.line)
+    end
+  end
+end

--- a/tools/validate/test/fixtures/ok-repo-docs.html
+++ b/tools/validate/test/fixtures/ok-repo-docs.html
@@ -1,0 +1,15 @@
+<html>
+<body>
+
+    <div>
+        <div>
+            <h1>H1 is OK here, this is outside the repo docs</h1>
+        </div>
+        <div class="repo-docs-content">
+            Some text
+            <h2>A title that is not H1, that's fine</h2>
+            more text
+        </div>
+    </div>
+</body>
+</html>

--- a/tools/validate/test/fixtures/repo-docs-with-h1.html
+++ b/tools/validate/test/fixtures/repo-docs-with-h1.html
@@ -1,0 +1,14 @@
+<html>
+<body>
+    <div>
+        <h1>H1 is OK here, this is outside the repo docs</h1>
+    </div>
+    <div>
+        <div class="repo-docs-content">
+            Some text
+            <h1>H1 is not OK here, this is inside the repo docs</h1>
+            more text
+        </div>
+    </div>
+</body>
+</html>

--- a/tools/validate/test/helper.rb
+++ b/tools/validate/test/helper.rb
@@ -22,7 +22,7 @@ def make_proofer(file, options)
   options[:log_level] ||= :error
   options[:disable_external] = true
   options[:enforce_https] = false
-  options[:checks] = 'UrlCheck'
+  options[:checks] = ['UrlCheck', 'RepoDocsCheck']
   HTMLProofer.check_file(file, options)
 end
 

--- a/tools/validate/test/repo_docs_check_test.rb
+++ b/tools/validate/test/repo_docs_check_test.rb
@@ -1,0 +1,33 @@
+require 'html-proofer'
+require_relative 'helper'
+
+require 'tools/validate/src/repo_docs_check'
+
+
+
+class TestRepoDocsCheck < Minitest::Test
+
+  def test_html_without_h1_passes
+    # Fixture
+    html = "#{FIXTURES_DIR}/ok-repo-docs.html"
+
+    # Test
+    proofer = run_proofer(html)
+
+    # Assert
+    assert_equal(proofer.failed_checks.length, 0)
+  end
+
+  def test_html_with_h1_fails
+    # Fixture
+    html = "#{FIXTURES_DIR}/repo-docs-with-h1.html"
+
+    # Test
+    proofer = run_proofer(html)
+
+    # Assert
+    assert_equal(proofer.failed_checks.length, 1)
+    assert_equal(proofer.failed_checks[0].description, "H1 tags not allowed in repo docs")
+  end
+
+end


### PR DESCRIPTION
This PR adds a check that there are no H1 tags in repo docs