### PR TITLE
Add tag support to id_links

### DIFF
--- a/src/_plugins/link.rb
+++ b/src/_plugins/link.rb
@@ -51,17 +51,24 @@ module Jekyll
             #
             #
             #
-            # Takes 1 argument
+            # Takes 1 or 2 arguments
             # - page id
+            # - url tag (optional)
             #
             # Example
             # {% id_link my_page_id %}
+            # {% id_link my_page_id; my-tag %}
 
             def initialize(tag_name, text, tokens)
                 super
                 params = parse_args(text)
 
                 @page_id = params[0]
+
+                @id = nil
+                if params.length > 1
+                    @id = params[1]
+                end
             end
 
             def render(context)
@@ -71,7 +78,12 @@ module Jekyll
 
                 page = pages[0]
 
-                '<a href="%1$s">%2$s</a>' % [page.url, page.data['title']]
+                url = page.url
+                if @id
+                    url =  url + '#' + @id
+                end
+
+                '<a href="%1$s">%2$s</a>' % [url, page.data['title']]
             end
         end
     end

--- a/test/_plugins/link_test.rb
+++ b/test/_plugins/link_test.rb
@@ -102,4 +102,28 @@ class TestLink < Testbase
     # Assert
     assert_html(expected, actual)
   end
+
+  def test_that_id_link_with_tag_renders
+    # Fixture
+    id = 'my_id'
+    url = '/my/url/'
+    title = "The title"
+
+    data = {'page_id' => id, 'title' => title}
+    page_mock = MiniTest::Mock.new()
+    page_mock.expect(:data, data)
+    page_mock.expect(:data, data)
+    page_mock.expect(:url, url)
+
+    @pages << page_mock
+
+    tag = '{% id_link my_id; my_tag %}'
+    expected = '<a href="/my/url/#my_tag">The title</a>'
+
+    # Test
+    actual = Liquid::Template.parse(tag).render!(nil, registers: {site: @site_mock})
+
+    # Assert
+    assert_html(expected, actual)
+  end
 end


### PR DESCRIPTION
id_links can now take a second argument to go to a header