### PR TITLE
Updated crazyflie-demos links

### DIFF
--- a/src/documentation/tutorials/getting-started-color-led-deck.md
+++ b/src/documentation/tutorials/getting-started-color-led-deck.md
@@ -74,7 +74,7 @@ The group consists of two parameters:
 
 {% si_step What's Next? %}
 * Learn how to control a Crazyflie with scripting and the Crazyflie Pyton lib using our [Software User Guides](/documentation/repository/crazyflie-lib-python/master/user-guides/).
-* Check out the [Color LED examples](https://github.com/bitcraze/crazyflie-lib-python/tree/master/examples/color_led_deck) in our Python lib.
-* Try out the [LED Color Cycle Example Firmware App](https://github.com/bitcraze/crazyflie-firmware/tree/master/examples/app_color_led_cycle) to see an example of how to create an app in the firmware to run light patterns for the Color LED deck.
+* Check out the [Color LED examples](https://github.com/bitcraze/crazyflie-demos/tree/main/demos/scripts/cflib/color_led_deck) using our Python lib.
+* Try out the [LED Color Cycle Example Firmware App](https://github.com/bitcraze/crazyflie-demos/tree/main/demos/firmware/color_led_cycle) to see an example of how to create an app in the firmware to run light patterns for the Color LED deck.
 {% endsi_step %}
 

--- a/src/documentation/tutorials/getting-started-with-stem-drone-bundle.md
+++ b/src/documentation/tutorials/getting-started-with-stem-drone-bundle.md
@@ -176,7 +176,7 @@ Landing!
 
 {% si_step what's next? %}
 * Explore the [motion commander](https://github.com/bitcraze/crazyflie-lib-python/blob/master/cflib/positioning/motion_commander.py) class. The class can do more then simple directional commands such as scripting using speed and time or together with events.
-* Try out the logging and parameter framework. The [basic logging](https://github.com/bitcraze/crazyflie-lib-python/blob/master/examples/basiclogSync.py) is a good example to start from or digg into the details on the [documentation](/documentation/repository/crazyflie-firmware/master/userguides/logparam/).
+* Try out the logging and parameter framework. The [basic logging](https://github.com/bitcraze/crazyflie-demos/tree/main/demos/scripts/cflib/logging/basiclog_sync) is a good example to start from or dig into the details on the [documentation](/documentation/repository/crazyflie-firmware/master/userguides/logparam/).
 * Connect a gamepad and with the {% poplink flow-deck %} to try optical flow stabilized flight. See the {% id_link getting-started-flow-deck %} tutorial.
 * Add one of the many [expansion deck boards](https://store.bitcraze.io/collections/decks), build your own deck using {% poplink prototyping-deck %} or even design it from ground up using the KiCad [deck template](https://github.com/bitcraze/crazyflie2-exp-template-electronics).
 {% endsi_step %}

--- a/src/documentation/tutorials/getting-started-with-stem-ranging-bundle.md
+++ b/src/documentation/tutorials/getting-started-with-stem-ranging-bundle.md
@@ -185,6 +185,6 @@ Demo terminated!
 {% si_step what's next? %}
 * Explore the different [example scripts](https://github.com/bitcraze/crazyflie-lib-python/blob/master/examples).
 * Explore the [motion commander](https://github.com/bitcraze/crazyflie-lib-python/blob/master/cflib/positioning/motion_commander.py) class. The class can do more then simple directional commands such as scripting using speed and time or together with events.
-* Try out the logging and parameter framework. The [basic logging](https://github.com/bitcraze/crazyflie-lib-python/blob/master/examples/basiclogSync.py) is a good example to start from or digg into the details on the [documentation](/documentation/repository/crazyflie-firmware/master/userguides/logparam/).
+* Try out the logging and parameter framework. The [basic logging](https://github.com/bitcraze/crazyflie-demos/tree/main/demos/scripts/cflib/logging/basiclog_sync) is a good example to start from or dig into the details on the [documentation](/documentation/repository/crazyflie-firmware/master/userguides/logparam/).
 * Connect a gamepad and with the {% poplink flow-deck %} to try optical flow stabilized flight.
 {% endsi_step %}

--- a/src/products/multi-ranger-deck.md
+++ b/src/products/multi-ranger-deck.md
@@ -29,7 +29,7 @@ The {% poplink multi-ranger-deck%} measures the distance to the nearest surface 
 
 The Multi-ranger can also be used as a starting point for experimenting with mapping and exploration.
 
-**Note:** The deck provides sensor data only. No collision avoidance or obstacle reaction is enabled by default. For examples of how to use the sensor data, see the [Crazyflie Python library examples for the Multi-ranger](https://github.com/bitcraze/crazyflie-lib-python/tree/master/examples/multiranger).
+**Note:** The deck provides sensor data only. No collision avoidance or obstacle reaction is enabled by default. For examples of how to use the sensor data, see the [Multi-ranger examples](https://github.com/bitcraze/crazyflie-demos/tree/main/demos/scripts/cflib/multiranger) in the [crazyflie-demos](https://github.com/bitcraze/crazyflie-demos) repository.
 
 
 {% endrow_text %}
@@ -85,7 +85,7 @@ Follow the [STEM bundle tutorial]({% id_url getting-started-stem-ranging-bundle 
 The Multi-ranger deck is being handled in [its driver in the crazyflie firmware](https://github.com/bitcraze/crazyflie-firmware/blob/master/src/deck/drivers/src/multiranger.c).
 
 #### Examples
-Check out the multi-ranger based python demos in the [Crazyflie Python Library](https://github.com/bitcraze/crazyflie-lib-python/tree/master/) example folder.
+In the [crazyflie-demos](https://github.com/bitcraze/crazyflie-demos) repository you can find [python scripts](https://github.com/bitcraze/crazyflie-demos/tree/main/demos/scripts/cflib/multiranger) and [firmware apps](https://github.com/bitcraze/crazyflie-demos/tree/main/demos/firmware) using the Multi-ranger deck.
 
 Here is the video of the point cloud example
 


### PR DESCRIPTION
Examples have moved from `crazyflie-lib-python` and `crazyflie-firmware` to `crazyflie-demos` but some links were not updated. This PR fixes that.